### PR TITLE
allow wildfly to use up to 4GB of heap and 4GB of permgen

### DIFF
--- a/wildfly@.service
+++ b/wildfly@.service
@@ -21,7 +21,7 @@ ExecStartPre=/usr/bin/docker pull ${DOCKER_REPO}:${VERSION}
 ExecStart=/bin/bash -c 'docker run -P --name ${CONTAINER} --restart=always \
   --env ADMIN_USERNAME=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/wildfly/admin-username?raw) \
   --env ADMIN_PASSWORD=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/wildfly/admin-password?raw) \
-  --env JAVA_OPTS="-Xms64m -Xmx4096m -XX:MaxPermSize=4096m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true" \
+  --env JAVA_OPTS="-Xms64m -Xmx8192m -XX:MaxPermSize=2048m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true" \
   ${DOCKER_REPO}:${VERSION}'
 
 ExecStop=/usr/bin/docker stop ${CONTAINER}

--- a/wildfly@.service
+++ b/wildfly@.service
@@ -21,7 +21,7 @@ ExecStartPre=/usr/bin/docker pull ${DOCKER_REPO}:${VERSION}
 ExecStart=/bin/bash -c 'docker run -P --name ${CONTAINER} --restart=always \
   --env ADMIN_USERNAME=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/wildfly/admin-username?raw) \
   --env ADMIN_PASSWORD=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/wildfly/admin-password?raw) \
-  --env JAVA_OPTS="-Xms1024m -Xmx4096m -XX:MaxPermSize=4096m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true" \
+  --env JAVA_OPTS="-Xms64m -Xmx4096m -XX:MaxPermSize=4096m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true" \
   ${DOCKER_REPO}:${VERSION}'
 
 ExecStop=/usr/bin/docker stop ${CONTAINER}

--- a/wildfly@.service
+++ b/wildfly@.service
@@ -21,6 +21,7 @@ ExecStartPre=/usr/bin/docker pull ${DOCKER_REPO}:${VERSION}
 ExecStart=/bin/bash -c 'docker run -P --name ${CONTAINER} --restart=always \
   --env ADMIN_USERNAME=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/wildfly/admin-username?raw) \
   --env ADMIN_PASSWORD=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/wildfly/admin-password?raw) \
+  --env JAVA_OPTS="-Xms1024m -Xmx4096m -XX:MaxPermSize=4096m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true" \
   ${DOCKER_REPO}:${VERSION}'
 
 ExecStop=/usr/bin/docker stop ${CONTAINER}


### PR DESCRIPTION
This was defaulting to 512MB of max heap and 256MB of max permgen before and we were seeing services crash w/ out of memory errors.

The CoreOS nodes each have 15GB of RAM, but non-WildFly things like RabbitMQ will want to use some of that too.

This also bumps up the initial heap size from 64MB to 1GB. That _could_ be a problem in dev, I suppose. Maybe @tank157 has some insight on whether that's a good change or not.

Finding the optimal balance here will likely require some more experience actually running these things in production.

No card, I just saw services crashing and the out-of-memory errors in the wildfly logs.
