### PR TITLE
set Linux locale env vars to en_US.UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM jboss/wildfly:8.2.1.Final
 MAINTAINER Democracy Works, Inc. <dev@democracy.works>
 
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
 WORKDIR /opt/jboss/wildfly
 
 USER root


### PR DESCRIPTION
This seems to fix all of the UTF-8 issues we've been seeing everywhere. Hooray!

Pivotal cards [first](https://www.pivotaltracker.com/story/show/109819774), [second](https://www.pivotaltracker.com/story/show/107502232), and [third](https://www.pivotaltracker.com/story/show/107310582).

I also opened an issue upstream about making UTF-8 the default in the `jboss/wildfly` image.
