### PR TITLE
Wildfly 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM jboss/wildfly:8.2.1.Final
+FROM jboss/wildfly:9.0.2.Final
 MAINTAINER Democracy Works, Inc. <dev@democracy.works>
 
 WORKDIR /opt/jboss/wildfly
 
 USER root
+
 RUN mkdir -p /var/log/remote/wildfly && \
     ln -s /var/log/remote/wildfly standalone/log && \
     chown -R jboss /var/log/remote/wildfly

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM quay.io/democracyworks/wildfly:8.2.1.Final
+FROM quay.io/democracyworks/wildfly:9.0.2.Final
 MAINTAINER Democracy Works, Inc. <dev@democracy.works>
 
 USER root


### PR DESCRIPTION
Since we're about to deploy the UTF-8 fix anyway, let's take the opportunity to get updated to the latest version of WildFly (9.0.2 as of today).

I've tested this locally in krakenstein and it seems to work just fine.
